### PR TITLE
Feature/Additional-MIME-Types

### DIFF
--- a/server/mime-types.js
+++ b/server/mime-types.js
@@ -1,26 +1,69 @@
 
 module.exports =
 {
+	// Text
 	TXT: "text/plain",
 	RTF: "application/rtf",
+
+	// Script
+	SHELL: "application/x-sh",
+	C_SHELL: "application/x-csh",
 	
+	// Web
 	HTML: "text/html",
+	XHTML: "application/xhtml+xml",
 	CSS: "text/css",
 	JS: "text/javascript",
 	JSON: "application/json",
 	XML: "application/xml",
+	PHP: "application/x-httpd-php",
 	
+	// Media (Image)
 	JPG: "image/jpg",
+	JPEG: "image/jpeg",
 	PNG: "image/png",
 	ICO: "image/x-icon",
+	TIFF: "image/tiff",
+	SVG: "image/svg+xml",
+	WEBP: "image/webp",
+
+	// Media (Video)
+	GIF: "image/gif",
+	MP4: "video/mp4",
+	MPEG: "video/mpeg",
+	OGV: "video/ogg",
+	AVI: "video/x-msvideo",
+	WEBM: "video/webm",
+
+	// Media (Audio)
+	MP3: "audio/mpeg",
+	OGG: "audio/ogg",
+	WAV: "audio/wav",
+	AAC: "audio/aac",
+	WEBA: "audio/webm",
 	
+	// Fonts
 	EOT: "application/vnd.ms-fontobject",
 	OTF: "font/otf",
 	TTF: "font/ttf",
 	WOFF: "font/woff",
 	WOFF2: "font/woff2",
 	
+	// Document
 	PDF: "application/pdf",
+	ODT: "application/vnd.oasis.opendocument.text",
+	ODS: "application/vnd.oasis.opendocument.spreadsheet",
+	ODP: "application/vnd.oasis.opendocument.presentation",
+
+	// Archive
 	ZIP: "application/zip",
-	JAR: "application/java-archive"
+	SEVEN_ZIP: "application/x-7z-compressed",
+	TAR: "application/x-tar",
+	GZIP: "application/gzip",
+	BZIP: "application/x-bzip",
+	RAR: "application/vnd.rar",
+	JAR: "application/java-archive",
+
+	// Binary
+	BIN: "application/octet-stream"
 };


### PR DESCRIPTION
Resolves Issue Number: #1 

---

Add additional MIME type file formats to the Server MIME type list that are available from the following categories:

- Scripts
- Web Files
- Media Files (Image, Video and Audio)
- Documents
- Archives
- Binary Files